### PR TITLE
Add []byte as base64 flag type and support direct binary from configmap binaryData section for said type

### DIFF
--- a/configmap/loglevel_change_test.go
+++ b/configmap/loglevel_change_test.go
@@ -54,6 +54,8 @@ func TestDynamicLogLevelAndBinaryFlag(t *testing.T) {
 	if err = os.WriteFile(binaryFlag, []byte{0, 1, 2, 3}, 0o644); err != nil {
 		t.Fatalf("unable to write %v: %v", binaryFlag, err)
 	}
+	// Time based tests aren't great, specially when ran on (slow) CI try to have notification not get events for above.
+	time.Sleep(1 * time.Second)
 	var u *configmap.Updater
 	log.SetLogLevel(log.Debug)
 	if u, err = configmap.Setup(flag.CommandLine, pDir); err != nil {
@@ -73,7 +75,8 @@ func TestDynamicLogLevelAndBinaryFlag(t *testing.T) {
 	if err = os.WriteFile(fName, []byte(" InFO\n\n"), 0o644); err != nil {
 		t.Fatalf("unable to write %v: %v", fName, err)
 	}
-	time.Sleep(1 * time.Second)
+	// Time based tests aren't great, specially when ran on (slow) CI but...
+	time.Sleep(2 * time.Second)
 	newLevel := log.GetLogLevel()
 	if newLevel != log.Info {
 		t.Errorf("Loglevel didn't change as expected, still %v %v", newLevel, newLevel.String())
@@ -81,11 +84,11 @@ func TestDynamicLogLevelAndBinaryFlag(t *testing.T) {
 	assert.Equal(t, binF.Get(), []byte{1, 0})
 	// put back debug
 	log.SetLogLevel(log.Debug)
-	assert.Equal(t, u.Errors(), 0)
+	assert.Equal(t, u.Errors(), 0, "should have 0 errors so far")
 	// Now create validation error on binary flag:
 	if err = os.WriteFile(binaryFlag, []byte{1, 2, 3, 4, 5}, 0o644); err != nil {
 		t.Fatalf("unable to write %v: %v", binaryFlag, err)
 	}
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, u.Errors(), 1)
+	time.Sleep(2 * time.Second)
+	assert.Equal(t, u.Errors(), 1, "should have 1 error picked up as we wrote > 4 bytes")
 }

--- a/configmap/updater.go
+++ b/configmap/updater.go
@@ -161,8 +161,16 @@ func (u *Updater) readFlagFile(fullPath string, dynamicOnly bool) error {
 	if err != nil {
 		return err
 	}
+	if v := dflag.IsBinary(flag); v != nil {
+		log.Infof("Updating binary %q to new blob (len %d)", flagName, len(content))
+		err = v.SetV(content)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 	str := string(content)
-	log.Infof("updating %v to %q", flagName, str)
+	log.Infof("Updating %q to %q", flagName, str)
 	// do not call flag.Value.Set, instead go through flagSet.Set to change "changed" state.
 	return u.flagSet.Set(flagName, str)
 }

--- a/configmap/updater.go
+++ b/configmap/updater.go
@@ -40,6 +40,7 @@ type Updater struct {
 	flagSet    *flag.FlagSet
 	done       chan bool
 	warnings   atomic.Int32 // Count of unknown flags that have been logged (increases at each iteration).
+	errors     atomic.Int32 // Count of validation errors that have been logged (increases at each iteration).
 }
 
 // Setup is a combination/shortcut for New+Initialize+Start.
@@ -133,6 +134,7 @@ func (u *Updater) readAll(dynamicOnly bool) error {
 				u.warnings.Add(1)
 			} else if !(errors.Is(err, errFlagNotDynamic) && dynamicOnly) {
 				errorStrings = append(errorStrings, fmt.Sprintf("flag %v: %v", f.Name(), err.Error()))
+				u.errors.Add(1)
 			}
 		}
 	}
@@ -146,6 +148,11 @@ func (u *Updater) readAll(dynamicOnly bool) error {
 // Return the warnings count.
 func (u *Updater) Warnings() int {
 	return int(u.warnings.Load())
+}
+
+// Return the errors count.
+func (u *Updater) Errors() int {
+	return int(u.errors.Load())
 }
 
 func (u *Updater) readFlagFile(fullPath string, dynamicOnly bool) error {
@@ -201,6 +208,7 @@ func (u *Updater) watchForUpdates() {
 					flagName := path.Base(event.Name)
 					if err := u.readFlagFile(event.Name, true); err != nil {
 						log.Errf("dflag: failed setting flag %s: %v", flagName, err.Error())
+						u.errors.Add(1)
 					}
 				case fsnotify.Chmod:
 				}

--- a/dyngeneric.go
+++ b/dyngeneric.go
@@ -278,8 +278,10 @@ func (d *DynValue[T]) String() string {
 	switch v := any(d.Get()).(type) {
 	case []string:
 		return strings.Join(v, ",")
+	case []byte:
+		return base64.StdEncoding.EncodeToString(v)
 	default:
-		return fmt.Sprintf("%v", d.Get())
+		return fmt.Sprintf("%v", v)
 	}
 }
 

--- a/dyngeneric.go
+++ b/dyngeneric.go
@@ -3,6 +3,7 @@
 package dflag
 
 import (
+	"encoding/base64"
 	"flag"
 	"fmt"
 	"strconv"
@@ -74,7 +75,7 @@ func ValidateDynSliceMinElements[T any](count int) func([]T) error {
 // DynValueTypes are the types currently supported by Parse[T] and thus by Dyn[T].
 // DynJSON is special.
 type DynValueTypes interface {
-	bool | time.Duration | float64 | int64 | string | []string | sets.Set[string]
+	bool | time.Duration | float64 | int64 | string | []string | sets.Set[string] | []byte
 }
 
 type DynValue[T any] struct {
@@ -189,6 +190,8 @@ func parse[T any](input string) (val T, err error) {
 		*v, err = strconv.ParseFloat(strings.TrimSpace(input), 64)
 	case *time.Duration:
 		*v, err = time.ParseDuration(input)
+	case *[]byte:
+		*v, err = base64.StdEncoding.DecodeString(input)
 	case *string:
 		*v = input
 	case *[]string:

--- a/dyngeneric.go
+++ b/dyngeneric.go
@@ -44,6 +44,15 @@ func IsFlagDynamic(f *flag.Flag) bool {
 	return df.IsDynamicFlag() // will clearly return true if it exists
 }
 
+// IsBinary returns the binary flag or nil depending on if the given Flag
+// is a []byte dynamic value or not (for confimap/file based setting).
+func IsBinary(f *flag.Flag) *DynValue[[]byte] {
+	if v, ok := f.Value.(*DynValue[[]byte]); ok {
+		return v
+	}
+	return nil
+}
+
 type DynamicBoolValueTag struct{}
 
 func (*DynamicBoolValueTag) IsBoolFlag() bool {

--- a/dyngeneric_test.go
+++ b/dyngeneric_test.go
@@ -78,6 +78,8 @@ func TestBinary(t *testing.T) {
 	err := set.Set("some_binary", "\nAAEC\n") // extra newlines are fine
 	assert.NoError(t, err, "setting value must succeed")
 	assert.Equal(t, []byte{0, 1, 2}, dynFlag.Get(), "value must be set after update")
+	str := dynFlag.String()
+	assert.Equal(t, "AAEC", str, "value when printed must be base64 encoded")
 	err = set.Set("some_binary", "foo bar")
 	assert.Error(t, err, "setting bogus base64 should fail")
 }

--- a/dyngeneric_test.go
+++ b/dyngeneric_test.go
@@ -75,7 +75,9 @@ func TestBinary(t *testing.T) {
 	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
 	dynFlag := Dyn(set, "some_binary", []byte{2, 1, 0}, "some binary values")
 	assert.Equal(t, []byte{2, 1, 0}, dynFlag.Get(), "value must be default after create")
-	err := set.Set("some_binary", "AAEC\n")
+	err := set.Set("some_binary", "\nAAEC\n") // extra newlines are fine
 	assert.NoError(t, err, "setting value must succeed")
 	assert.Equal(t, []byte{0, 1, 2}, dynFlag.Get(), "value must be set after update")
+	err = set.Set("some_binary", "foo bar")
+	assert.Error(t, err, "setting bogus base64 should fail")
 }

--- a/dyngeneric_test.go
+++ b/dyngeneric_test.go
@@ -44,11 +44,16 @@ func TestArrayToString(t *testing.T) {
 	s := []string{"z", "a", "c", "b"}
 	f := New(s, "test array")
 	Flag("testing123", f)
-	defValue := flag.CommandLine.Lookup("testing123").DefValue
+	flag := flag.CommandLine.Lookup("testing123")
+	defValue := flag.DefValue
 	// order preserved unlike for sets.Set where we sort
 	str := f.String()
 	assert.Equal(t, "z,a,c,b", str)
 	assert.Equal(t, "z,a,c,b", defValue)
+	b := IsBinary(flag)
+	if b != nil {
+		t.Errorf("flag %v isn't binary yet got non nil: %v", flag, b)
+	}
 }
 
 func TestRemoveCommon(t *testing.T) {
@@ -82,4 +87,9 @@ func TestBinary(t *testing.T) {
 	assert.Equal(t, "AAEC", str, "value when printed must be base64 encoded")
 	err = set.Set("some_binary", "foo bar")
 	assert.Error(t, err, "setting bogus base64 should fail")
+	flag := set.Lookup("some_binary")
+	assert.True(t, IsFlagDynamic(flag), "flag must be dynamic")
+	if IsBinary(flag) == nil {
+		t.Errorf("flag %v isn't binary yet it should", flag)
+	}
 }

--- a/dyngeneric_test.go
+++ b/dyngeneric_test.go
@@ -70,3 +70,12 @@ func TestRemoveCommon(t *testing.T) {
 	setBB.Remove("c")
 	assert.False(t, setBB.Has("c"))
 }
+
+func TestBinary(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	dynFlag := Dyn(set, "some_binary", []byte{2, 1, 0}, "some binary values")
+	assert.Equal(t, []byte{2, 1, 0}, dynFlag.Get(), "value must be default after create")
+	err := set.Set("some_binary", "AAEC\n")
+	assert.NoError(t, err, "setting value must succeed")
+	assert.Equal(t, []byte{0, 1, 2}, dynFlag.Get(), "value must be set after update")
+}

--- a/examples/server_kube/http.go
+++ b/examples/server_kube/http.go
@@ -49,8 +49,9 @@ var (
 			},
 		},
 		"An arbitrary JSON struct.")
-	dynArray = dflag.New([]string{"z", "b", "a"}, "An array of strings (comma separated)")
-	dynSet   = dflag.New(sets.New("z", "b", "a"), "An set of strings (comma separated)")
+	dynArray  = dflag.New([]string{"z", "b", "a"}, "An array of strings (comma separated)")
+	dynSet    = dflag.New(sets.New("z", "b", "a"), "An set of strings (comma separated)")
+	dynBinary = dflag.Dyn(flag.CommandLine, "example_binary", []byte{0x00, 0x01, 0x02}, "A binary value")
 )
 
 func main() {


### PR DESCRIPTION
For #51 : the flag as base64 text on cmd line part, auto decoding to binary, and when in a file/configmap allow verbatim (needs to be binaryData key instead of data for a kubernetes configmap)


- [x] test that a confimap binaryData really ends up as binary once mounted
- [x] add binary type with base64 for cli and no base64 for cmap
- [x] special handling in configmap 