### PR TITLE
we can get double events so double errors; also it can take a while to get events,... so sleep 3s

### DIFF
--- a/configmap/loglevel_change_test.go
+++ b/configmap/loglevel_change_test.go
@@ -89,6 +89,10 @@ func TestDynamicLogLevelAndBinaryFlag(t *testing.T) {
 	if err = os.WriteFile(binaryFlag, []byte{1, 2, 3, 4, 5}, 0o644); err != nil {
 		t.Fatalf("unable to write %v: %v", binaryFlag, err)
 	}
-	time.Sleep(2 * time.Second)
-	assert.Equal(t, u.Errors(), 1, "should have 1 error picked up as we wrote > 4 bytes")
+	time.Sleep(3 * time.Second)
+	// We might get more than 1 event for some reasons, so more than 1 error
+	errCount := u.Errors()
+	if errCount < 1 {
+		t.Errorf("Expected at least 1 error because we wrote more than validator accepts, got %d", errCount)
+	}
 }


### PR DESCRIPTION

try avoid flacky tests (yet... with timing...)